### PR TITLE
Make srv_async_unix public

### DIFF
--- a/src/srv.rs
+++ b/src/srv.rs
@@ -409,7 +409,7 @@ where
     }
 }
 
-async fn srv_async_unix<Fs>(filesystem: Fs, addr: &str) -> Result<()>
+pub async fn srv_async_unix<Fs>(filesystem: Fs, addr: &str) -> Result<()>
 where
     Fs: 'static + Filesystem + Send + Sync + Clone,
 {


### PR DESCRIPTION
The problem with `srv_async` is that it creates constraints on the naming of the unix socket, specifically, that the name must end in `:<port>`.

This is not compatible with my use case (wiring up to a firecracker-vm vsocket, which has its own naming convention for sockets).

This is a trivial PR to simply expose the `srv_async_unix` method so I can provide my own address.